### PR TITLE
Update README.md to automatically support derivative distros.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ sudo chmod a+r /etc/apt/keyrings/xlibre-deb.asc
 cat <<EOF | sudo tee /etc/apt/sources.list.d/xlibre-deb.sources
 Types: deb deb-src
 URIs: https://xlibre-deb.github.io/ubuntu/
-Suites: $(. /etc/upstream-release/lsb-release && echo "$DISTRIB_CODENAME)
+Suites: $(. /etc/os-release && echo "$UBUNTU_CODENAME)
 Components: main
 Architectures: $(dpkg --print-architecture)
 Signed-By: /etc/apt/keyrings/xlibre-deb.asc

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ sudo chmod a+r /etc/apt/keyrings/xlibre-deb.asc
 cat <<EOF | sudo tee /etc/apt/sources.list.d/xlibre-deb.sources
 Types: deb deb-src
 URIs: https://xlibre-deb.github.io/ubuntu/
-Suites: $(. /etc/os-release && echo "$VERSION_CODENAME")
+Suites: $(. /etc/upstream-release/lsb-release && echo "$DISTRIB_CODENAME)
 Components: main
 Architectures: $(dpkg --print-architecture)
 Signed-By: /etc/apt/keyrings/xlibre-deb.asc


### PR DESCRIPTION
Pulling the os-release entry directly will cause problems with derivatives such as Linux Mint as they will pull the derivative code name instead of the Ubuntu code name, which will cause the install to fail as there is no "Xia" repository. Pulling from upstream-release solves that and is the recommended solution by Ubuntu as that file will have the correct code name, even on Ubuntu directly